### PR TITLE
Added binding for MurmurHash2

### DIFF
--- a/murmurhash/mrmr.pxd
+++ b/murmurhash/mrmr.pxd
@@ -1,7 +1,7 @@
 from libc.stdint cimport uint64_t, int64_t, uint32_t
 
 
-cdef uint32_t hash32(void* key, int length, uint32_t seed) nogil
+cdef uint32_t hash32(void* key, int length, uint32_t seed, int version) nogil
 cdef uint64_t hash64(void* key, int length, uint64_t seed) nogil
 cdef uint64_t real_hash64(void* key, int length, uint64_t seed) nogil
 cdef void hash128_x86(const void* key, int len, uint32_t seed, void* out) nogil


### PR DESCRIPTION
Hi,

This adds cython bindings for MurmurHash2 method. We use the native implementation in [xeus](https://github.com/jupyter-xeus/xeus) and a webasm implementation in [jupyterlab](https://github.com/jupyterlab/jupyterlab). We would need the python bindings for [ipykernel](https://github.com/ipython/ipykernel).