### PR TITLE
Murmurhash3: fix big-endian

### DIFF
--- a/murmurhash/MurmurHash3.cpp
+++ b/murmurhash/MurmurHash3.cpp
@@ -60,17 +60,37 @@ inline uint64_t rotl64 ( uint64_t x, int8_t r )
 #endif // !defined(_MSC_VER)
 
 //-----------------------------------------------------------------------------
-// Block read - if your platform needs to do endian-swapping or can only
-// handle aligned reads, do the conversion here
-
+// Block read - on little-endian machines this is a single load,
+// while on big-endian or unknown machines the byte accesses should
+// still get optimized into the most efficient instruction.
 FORCE_INLINE uint32_t getblock ( const uint32_t * p, int i )
 {
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   return p[i];
+#else
+  const uint8_t *c = (const uint8_t *)&p[i];
+  return (uint32_t)c[0] |
+	 (uint32_t)c[1] <<  8 |
+	 (uint32_t)c[2] << 16 |
+	 (uint32_t)c[3] << 24;
+#endif
 }
 
 FORCE_INLINE uint64_t getblock ( const uint64_t * p, int i )
 {
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   return p[i];
+#else
+  const uint8_t *c = (const uint8_t *)&p[i];
+  return (uint64_t)c[0] |
+	 (uint64_t)c[1] <<  8 |
+	 (uint64_t)c[2] << 16 |
+	 (uint64_t)c[3] << 24 |
+	 (uint64_t)c[4] << 32 |
+	 (uint64_t)c[5] << 40 |
+	 (uint64_t)c[6] << 48 |
+	 (uint64_t)c[7] << 56;
+#endif
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This modifies the getblock() helpers to produce the same result regardless
of endianess.

Tested for s390x Linux, making sure that the result is now the same
as on other architectures, and by looking at the object code to ensure
that it uses the most efficient instructions (load reversed LRV/LRVG)
for accessing the input.

Signed-off-by: Arnd Bergmann <arnd@arndb.de>