### PR TITLE
Murmurhash2: make it endian neutral

### DIFF
--- a/murmurhash/MurmurHash2.cpp
+++ b/murmurhash/MurmurHash2.cpp
@@ -31,6 +31,40 @@
 #define BIG_CONSTANT(x) (x##LLU)
 
 #endif // !defined(_MSC_VER)
+//
+//-----------------------------------------------------------------------------
+// Block read - on little-endian machines this is a single load,
+// while on big-endian or unknown machines the byte accesses should
+// still get optimized into the most efficient instruction.
+static inline uint32_t getblock ( const uint32_t * p )
+{
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  return *p;
+#else
+  const uint8_t *c = (const uint8_t *)p;
+  return (uint32_t)c[0] |
+	 (uint32_t)c[1] <<  8 |
+	 (uint32_t)c[2] << 16 |
+	 (uint32_t)c[3] << 24;
+#endif
+}
+
+static inline uint64_t getblock ( const uint64_t * p )
+{
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  return *p;
+#else
+  const uint8_t *c = (const uint8_t *)p;
+  return (uint64_t)c[0] |
+	 (uint64_t)c[1] <<  8 |
+	 (uint64_t)c[2] << 16 |
+	 (uint64_t)c[3] << 24 |
+	 (uint64_t)c[4] << 32 |
+	 (uint64_t)c[5] << 40 |
+	 (uint64_t)c[6] << 48 |
+	 (uint64_t)c[7] << 56;
+#endif
+}
 
 //-----------------------------------------------------------------------------
 
@@ -52,7 +86,7 @@ uint32_t MurmurHash2 ( const void * key, int len, uint32_t seed )
 
   while(len >= 4)
   {
-    uint32_t k = *(uint32_t*)data;
+    uint32_t k = getblock((const uint32_t *)data);
 
     k *= m;
     k ^= k >> r;
@@ -105,7 +139,7 @@ uint64_t MurmurHash64A ( const void * key, int len, uint64_t seed )
 
   while(data != end)
   {
-    uint64_t k = *data++;
+    uint64_t k = getblock(data++);
 
     k *= m; 
     k ^= k >> r; 
@@ -151,12 +185,12 @@ uint64_t MurmurHash64B ( const void * key, int len, uint64_t seed )
 
   while(len >= 8)
   {
-    uint32_t k1 = *data++;
+    uint32_t k1 = getblock(data++);
     k1 *= m; k1 ^= k1 >> r; k1 *= m;
     h1 *= m; h1 ^= k1;
     len -= 4;
 
-    uint32_t k2 = *data++;
+    uint32_t k2 = getblock(data++);
     k2 *= m; k2 ^= k2 >> r; k2 *= m;
     h2 *= m; h2 ^= k2;
     len -= 4;
@@ -164,7 +198,7 @@ uint64_t MurmurHash64B ( const void * key, int len, uint64_t seed )
 
   if(len >= 4)
   {
-    uint32_t k1 = *data++;
+    uint32_t k1 = getblock(data++);
     k1 *= m; k1 ^= k1 >> r; k1 *= m;
     h1 *= m; h1 ^= k1;
     len -= 4;
@@ -215,7 +249,7 @@ uint32_t MurmurHash2A ( const void * key, int len, uint32_t seed )
 
   while(len >= 4)
   {
-    uint32_t k = *(uint32_t*)data;
+    uint32_t k = getblock((const uint32_t *)data);
 
     mmix(h,k);
 
@@ -278,7 +312,7 @@ public:
 
     while(len >= 4)
     {
-      uint32_t k = *(uint32_t*)data;
+      uint32_t k = getblock((const uint32_t *)data);
 
       mmix(m_hash,k);
 
@@ -310,7 +344,7 @@ private:
   {
     while( len && ((len<4) || m_count) )
     {
-      m_tail |= (*data++) << (m_count * 8);
+      m_tail |= *data++ << (m_count * 8);
 
       m_count++;
       len--;
@@ -427,7 +461,7 @@ uint32_t MurmurHashAligned2 ( const void * key, int len, uint32_t seed )
 
     while(len >= 4)
     {
-      d = *(uint32_t *)data;
+      d = getblock((const uint32_t *)data);
       t = (t >> sr) | (d << sl);
 
       uint32_t k = t;
@@ -492,7 +526,7 @@ uint32_t MurmurHashAligned2 ( const void * key, int len, uint32_t seed )
   {
     while(len >= 4)
     {
-      uint32_t k = *(uint32_t *)data;
+      uint32_t k = getblock((const uint32_t *)data);
 
       MIX(h,k,m);
 


### PR DESCRIPTION
Use the same logic as Murmurhash3 to load little-endian data from
the input key in all variants of Murmurhash2. The resulting object
code is unchanged on x86, and it does the correct thing on s390,
producing the same result while using the load-reverse instructions.

This is still broken on architectures that cannot handle unaligned
input, but those are becoming very rare.

Signed-off-by: Arnd Bergmann <arnd@arndb.de>