### PR TITLE
Murmurhash3: optimize tail load

### DIFF
--- a/murmurhash/MurmurHash3.cpp
+++ b/murmurhash/MurmurHash3.cpp
@@ -263,6 +263,77 @@ void MurmurHash3_x86_128 ( const void * key, const int len,
 
 //-----------------------------------------------------------------------------
 
+static void MurmurHash3_x64_128_short ( const void * key, const int len,
+                           const uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+
+  uint64_t h1 = seed;
+  uint64_t h2 = seed;
+
+  uint64_t c1 = BIG_CONSTANT(0x87c37b91114253d5);
+  uint64_t c2 = BIG_CONSTANT(0x4cf5ad432745937f);
+
+  //----------
+  // same as tail processing, but avoid out-of-range access
+  uint64_t k1 = 0;
+  uint64_t k2 = 0;
+
+  switch(len)
+  {
+  case 15:
+  case 14:
+  case 13:
+  case 12:
+  case 11:
+  case 10:
+  case 9:
+	   k2 = getblock((const uint64_t *)(data + len - 8), 0);
+	   k2 >>= (16 - len) * 8;
+	   k2 *= c2; k2  = ROTL64(k2, 33); k2 *= c1; h2 ^= k2;
+	   /* fallthrough */
+  case 8:
+	   k1 = getblock((const uint64_t *)data, 0);
+	   k1 *= c1; k1  = ROTL64(k1, 31); k1 *= c2; h1 ^= k1;
+	   break;
+
+  case 7:
+  case 6:
+  case 5:
+	   k1 = getblock((const uint32_t *)(data + len - 4), 0);
+	   k1 >>= (8 - len) * 8;
+	   k1 << 32;
+	   /* fallthrough */
+  case 4:
+	   k1 |= getblock((const uint32_t *)data, 0);
+	   k1 *= c1; k1  = ROTL64(k1, 31); k1 *= c2; h1 ^= k1;
+	   break;
+
+  case  3: k1 ^= uint64_t(data[ 2]) << 16;
+  case  2: k1 ^= uint64_t(data[ 1]) << 8;
+  case  1: k1 ^= uint64_t(data[ 0]) << 0;
+           k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+	   break;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len;
+
+  h1 += h2;
+  h2 += h1;
+
+  h1 = fmix(h1);
+  h2 = fmix(h2);
+
+  h1 += h2;
+  h2 += h1;
+
+  ((uint64_t*)out)[0] = h1;
+  ((uint64_t*)out)[1] = h2;
+}
+
 void MurmurHash3_x64_128 ( const void * key, const int len,
                            const uint32_t seed, void * out )
 {
@@ -277,6 +348,9 @@ void MurmurHash3_x64_128 ( const void * key, const int len,
 
   //----------
   // body
+
+  if (!nblocks)
+	  return MurmurHash3_x64_128_short(key, len, seed, out);
 
   const uint64_t * blocks = (const uint64_t *)(data);
 
@@ -295,34 +369,30 @@ void MurmurHash3_x64_128 ( const void * key, const int len,
   }
 
   //----------
-  // tail
+  // tail: read last 64-bit word aligned to end
 
   const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
 
   uint64_t k1 = 0;
   uint64_t k2 = 0;
+  int remain = len & 15;
 
-  switch(len & 15)
-  {
-  case 15: k2 ^= uint64_t(tail[14]) << 48;
-  case 14: k2 ^= uint64_t(tail[13]) << 40;
-  case 13: k2 ^= uint64_t(tail[12]) << 32;
-  case 12: k2 ^= uint64_t(tail[11]) << 24;
-  case 11: k2 ^= uint64_t(tail[10]) << 16;
-  case 10: k2 ^= uint64_t(tail[ 9]) << 8;
-  case  9: k2 ^= uint64_t(tail[ 8]) << 0;
-           k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+  if (remain > 8) {
+    k1 = getblock((uint64_t *)tail, 0);
 
-  case  8: k1 ^= uint64_t(tail[ 7]) << 56;
-  case  7: k1 ^= uint64_t(tail[ 6]) << 48;
-  case  6: k1 ^= uint64_t(tail[ 5]) << 40;
-  case  5: k1 ^= uint64_t(tail[ 4]) << 32;
-  case  4: k1 ^= uint64_t(tail[ 3]) << 24;
-  case  3: k1 ^= uint64_t(tail[ 2]) << 16;
-  case  2: k1 ^= uint64_t(tail[ 1]) << 8;
-  case  1: k1 ^= uint64_t(tail[ 0]) << 0;
-           k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
-  };
+    k1 *= c1; k1  = ROTL64(k1, 31); k1 *= c2; h1 ^= k1;
+
+    k2 = getblock((uint64_t *)(tail + 8 - (16 - remain)), 0);
+    k2 >>= ((16 - remain) * 8);
+
+    k2 *= c2; k2  = ROTL64(k2, 33); k2 *= c1; h2 ^= k2;
+
+  } else if (remain) {
+    k1 = getblock((uint64_t *)tail - (8 - remain), 0);
+    k1 >>= ((8 - remain) * 8);
+
+    k1 *= c1; k1  = ROTL64(k1, 31); k1 *= c2; h1 ^= k1;
+  }
 
   //----------
   // finalization


### PR DESCRIPTION
Instead of accessing each byte individually, reduce the number of
loads and shifts/mask operations to speed up hashing short strings.

Signed-off-by: Arnd Bergmann <arnd@arndb.de>