### PR TITLE
Replace mmh3 comparisons in tests

### DIFF
--- a/murmurhash/tests/test_against_mmh3.py
+++ b/murmurhash/tests/test_against_mmh3.py
@@ -1,9 +1,0 @@
-import mmh3
-import murmurhash.mrmr
-
-
-def test_hash32_matches_mmh3():
-    string = "hello world"
-    assert mmh3.hash(string) == murmurhash.mrmr.hash(string)
-    string = "anxiety"
-    assert mmh3.hash(string) == murmurhash.mrmr.hash(string)

--- a/murmurhash/tests/test_hash.py
+++ b/murmurhash/tests/test_hash.py
@@ -1,0 +1,6 @@
+import murmurhash.mrmr
+
+
+def test_hashes():
+    assert murmurhash.mrmr.hash("hello world") == 1586663183
+    assert murmurhash.mrmr.hash("anxiety") == -1859125401

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 cython>=0.23
 pytest
-mmh3 # Only for testing


### PR DESCRIPTION
Compare to hard-coded hashes rather than `mmh3`, since the underlying code diverges and `mmh3` is not endian-neutral.