### PR TITLE
Keep setuptools below 65 since it removed support from msvccompiler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools",
+    "setuptools<65",
     "cython>=0.25",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
It doesn't build anymore since there was a breaking change in setuptools that affect this package.

See: https://github.com/pypa/setuptools/blob/main/CHANGES.rst#breaking-changes