### PR TITLE
Add noexcept to cdef nogil functions

### DIFF
--- a/murmurhash/about.py
+++ b/murmurhash/about.py
@@ -1,5 +1,5 @@
 __title__ = "murmurhash"
-__version__ = "1.0.12"
+__version__ = "1.0.13"
 __summary__ = "Cython bindings for MurmurHash"
 __uri__ = "https://github.com/explosion/murmurhash"
 __author__ = "Explosion"

--- a/murmurhash/mrmr.pxd
+++ b/murmurhash/mrmr.pxd
@@ -1,8 +1,8 @@
 from libc.stdint cimport uint64_t, int64_t, uint32_t
 
 
-cdef uint32_t hash32(void* key, int length, uint32_t seed) nogil
-cdef uint64_t hash64(void* key, int length, uint64_t seed) nogil
-cdef uint64_t real_hash64(void* key, int length, uint64_t seed) nogil
-cdef void hash128_x86(const void* key, int len, uint32_t seed, void* out) nogil
-cdef void hash128_x64(const void* key, int len, uint32_t seed, void* out) nogil
+cdef uint32_t hash32(void* key, int length, uint32_t seed) noexcept nogil
+cdef uint64_t hash64(void* key, int length, uint64_t seed) noexcept nogil
+cdef uint64_t real_hash64(void* key, int length, uint64_t seed) noexcept nogil
+cdef void hash128_x86(const void* key, int len, uint32_t seed, void* out) noexcept nogil
+cdef void hash128_x64(const void* key, int len, uint32_t seed, void* out) noexcept nogil

--- a/murmurhash/mrmr.pyx
+++ b/murmurhash/mrmr.pyx
@@ -2,35 +2,35 @@ from libc.stdint cimport uint64_t, int64_t, int32_t
 
 
 cdef extern from "murmurhash/MurmurHash3.h":
-    void MurmurHash3_x86_32(void * key, uint64_t len, uint64_t seed, void* out) nogil
-    void MurmurHash3_x86_128(void * key, int len, uint32_t seed, void* out) nogil
-    void MurmurHash3_x64_128(void * key, int len, uint32_t seed, void* out) nogil
+    void MurmurHash3_x86_32(void * key, uint64_t len, uint64_t seed, void* out) noexcept nogil
+    void MurmurHash3_x86_128(void * key, int len, uint32_t seed, void* out) noexcept nogil
+    void MurmurHash3_x64_128(void * key, int len, uint32_t seed, void* out) noexcept nogil
 
 cdef extern from "murmurhash/MurmurHash2.h":
-    uint64_t MurmurHash64A(void * key, int length, uint32_t seed) nogil
-    uint64_t MurmurHash64B(void * key, int length, uint32_t seed) nogil
+    uint64_t MurmurHash64A(void * key, int length, uint32_t seed) noexcept nogil
+    uint64_t MurmurHash64B(void * key, int length, uint32_t seed) noexcept nogil
 
 
-cdef uint32_t hash32(void* key, int length, uint32_t seed) nogil:
+cdef uint32_t hash32(void* key, int length, uint32_t seed) noexcept nogil:
     cdef int32_t out
     MurmurHash3_x86_32(key, length, seed, &out)
     return out
 
 
-cdef uint64_t hash64(void* key, int length, uint64_t seed) nogil:
+cdef uint64_t hash64(void* key, int length, uint64_t seed) noexcept nogil:
     return MurmurHash64A(key, length, seed)
 
-cdef uint64_t real_hash64(void* key, int length, uint64_t seed) nogil:
+cdef uint64_t real_hash64(void* key, int length, uint64_t seed) noexcept nogil:
     cdef uint64_t[2] out
     MurmurHash3_x86_128(key, length, seed, &out)
     return out[1]
 
 
-cdef void hash128_x86(const void* key, int length, uint32_t seed, void* out) nogil:
+cdef void hash128_x86(const void* key, int length, uint32_t seed, void* out) noexcept nogil:
     MurmurHash3_x86_128(key, length, seed, out)
 
 
-cdef void hash128_x64(const void* key, int length, uint32_t seed, void* out) nogil:
+cdef void hash128_x64(const void* key, int length, uint32_t seed, void* out) noexcept nogil:
     MurmurHash3_x64_128(key, length, seed, out)
 
 


### PR DESCRIPTION
When compiling with Cython 3, nogil functions need noexcept explicitly, or they'll acquire the gil, causing potential performance problems.